### PR TITLE
fixed typo in usage tutorial and catching error if domain does not exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Then just put this in your model e. g:
 
 Or - if you'd like to use it outside of your models:
 
-    EmailValidator.check(youremail)
+    EmailVerifier.check(youremail)
 
 This method will return true or false, or - will throw exception 
 with nicely detailed info about what's wrong.

--- a/lib/email_verifier/checker.rb
+++ b/lib/email_verifier/checker.rb
@@ -28,6 +28,8 @@ class EmailVerifier::Checker
       mxs << { priority: rr.preference, address: rr.exchange.to_s }
     end
     mxs.sort_by { |mx| mx[:priority] }
+  rescue Dnsruby::NXDomain
+    raise EmailVerifier::NoMailServerException.new("#{domain} does not exist") 
   end
 
   def is_connected


### PR DESCRIPTION
While checking email with domain that does not exist it throwed Dnsruby::NXDomain exception so I rescued it.
