### PR TITLE
Closes the smtp connection after checking the email.

### DIFF
--- a/lib/email_verifier/checker.rb
+++ b/lib/email_verifier/checker.rb
@@ -55,8 +55,13 @@ class EmailVerifier::Checker
 
   def verify
     self.mailfrom @user_email
-    self.rcptto(@email)
-    @smtp.finish if (@smtp && @smtp.started?)
+    self.rcptto(@email).tap do
+      close_connection
+    end
+  end
+
+  def close_connection
+    @smtp.finish if @smtp && @smtp.started?
   end
 
   def mailfrom(address)

--- a/lib/email_verifier/checker.rb
+++ b/lib/email_verifier/checker.rb
@@ -56,6 +56,7 @@ class EmailVerifier::Checker
   def verify
     self.mailfrom @user_email
     self.rcptto(@email)
+    @smtp.finish if (@smtp && @smtp.started?)
   end
 
   def mailfrom(address)


### PR DESCRIPTION
close #15 

Some servers not support many concurrent SMTP connections:

``` ruby
1..20.times do
  EmailVerifier.check("user@bhmequipamentos.com.br")
end
```

SMTP raised: 421 Too many concurrent SMTP connections from this IP address; please try again later. until remove all served so EmailVerifier raise: EmailVerifier :: OutOfMailServersException: Unable to connect to any one of ...

Connections are closed by timeout.
