### PR TITLE
Remove rails dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ It also:
 
 Add this line to your application's Gemfile:
 
+    # place it at the bottom of rails/activesupport if you're working with them.
     gem 'email_verifier'
 
 And then execute:

--- a/email_verifier.gemspec
+++ b/email_verifier.gemspec
@@ -16,7 +16,6 @@ Gem::Specification.new do |gem|
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
-  gem.add_runtime_dependency(%q<rails>, [">= 3.0.0"])
   gem.add_runtime_dependency(%q<dnsruby>, [">= 1.5"])
   gem.license = 'MIT'
 end

--- a/lib/email_verifier/validates_email_realness.rb
+++ b/lib/email_verifier/validates_email_realness.rb
@@ -1,35 +1,37 @@
-ActiveSupport.on_load(:active_record) do
-  
-  module EmailVerifier
-    module ValidatesEmailRealness
-  
-      module Validator
-        class EmailRealnessValidator < ActiveModel::EachValidator
-          def validate_each(record, attribute, value)
-            begin
-              record.errors.add attribute, I18n.t('errors.messages.email_verifier.email_not_real') unless EmailVerifier.check(value)
-            rescue EmailVerifier::OutOfMailServersException
-              record.errors.add attribute, I18n.t('errors.messages.email_verifier.out_of_mail_server')
-            rescue EmailVerifier::NoMailServerException
-              record.errors.add attribute, I18n.t('errors.messages.email_verifier.no_mail_server')
-            rescue EmailVerifier::FailureException
-              record.errors.add attribute, I18n.t('errors.messages.email_verifier.failure')
-        	  rescue Exception
-        	    record.errors.add attribute, I18n.t('errors.messages.email_verifier.exception')
+if defined?(ActiveSupport)
+  ActiveSupport.on_load(:active_record) do
+
+    module EmailVerifier
+      module ValidatesEmailRealness
+
+        module Validator
+          class EmailRealnessValidator < ActiveModel::EachValidator
+            def validate_each(record, attribute, value)
+              begin
+                record.errors.add attribute, I18n.t('errors.messages.email_verifier.email_not_real') unless EmailVerifier.check(value)
+              rescue EmailVerifier::OutOfMailServersException
+                record.errors.add attribute, I18n.t('errors.messages.email_verifier.out_of_mail_server')
+              rescue EmailVerifier::NoMailServerException
+                record.errors.add attribute, I18n.t('errors.messages.email_verifier.no_mail_server')
+              rescue EmailVerifier::FailureException
+                record.errors.add attribute, I18n.t('errors.messages.email_verifier.failure')
+              rescue Exception
+                record.errors.add attribute, I18n.t('errors.messages.email_verifier.exception')
+              end
             end
           end
         end
-      end
-  
-      module ClassMethods
-        def validates_email_realness_of(*attr_names)
-          validates_with ActiveRecord::Base::EmailRealnessValidator, _merge_attributes(attr_names)
+
+        module ClassMethods
+          def validates_email_realness_of(*attr_names)
+            validates_with ActiveRecord::Base::EmailRealnessValidator, _merge_attributes(attr_names)
+          end
         end
+
       end
-  
     end
+
+    ActiveRecord::Base.send(:include, EmailVerifier::ValidatesEmailRealness::Validator)
+    ActiveRecord::Base.send(:extend,  EmailVerifier::ValidatesEmailRealness::ClassMethods)
   end
-  
-  ActiveRecord::Base.send(:include, EmailVerifier::ValidatesEmailRealness::Validator)
-  ActiveRecord::Base.send(:extend,  EmailVerifier::ValidatesEmailRealness::ClassMethods)
 end


### PR DESCRIPTION
ActiveSupport dependency is only needed for validator, and it is unnecessary for plain ruby environment.
I want to use this gem without loading activerecord.
Please review about this change.