### PR TITLE
Expose cause for EmailVerifier::OutOfMailServersException

### DIFF
--- a/lib/email_verifier/checker.rb
+++ b/lib/email_verifier/checker.rb
@@ -5,7 +5,7 @@ class EmailVerifier::Checker
 
   ##
   # Returns server object for given email address or throws exception
-  # Object returned isn't yet connected. It has internally a list of 
+  # Object returned isn't yet connected. It has internally a list of
   # real mail servers got from MX dns lookup
   def initialize(address)
     @email   = address
@@ -14,7 +14,7 @@ class EmailVerifier::Checker
     raise EmailVerifier::NoMailServerException.new("No mail server for #{address}") if @servers.empty?
     @smtp    = nil
 
-    # this is because some mail servers won't give any info unless 
+    # this is because some mail servers won't give any info unless
     # a real user asks for it:
     @user_email = EmailVerifier.config.verifier_email
     _, @user_domain = @user_email.split "@"
@@ -29,7 +29,7 @@ class EmailVerifier::Checker
     end
     mxs.sort_by { |mx| mx[:priority] }
   rescue Dnsruby::NXDomain
-    raise EmailVerifier::NoMailServerException.new("#{domain} does not exist") 
+    raise EmailVerifier::NoMailServerException.new("#{domain} does not exist")
   end
 
   def is_connected
@@ -39,13 +39,14 @@ class EmailVerifier::Checker
   def connect
     begin
       server = next_server
-      raise EmailVerifier::OutOfMailServersException.new("Unable to connect to any one of mail servers for #{@email}") if server.nil?
       @smtp = Net::SMTP.start server[:address], 25, @user_domain
       return true
-    rescue EmailVerifier::OutOfMailServersException => e
-      raise EmailVerifier::OutOfMailServersException, e.message
     rescue => e
-      retry
+      if @servers.count > 0
+        retry
+      else
+        raise EmailVerifier::OutOfMailServersException.new("Unable to connect to any one of mail servers for #{@email}")
+      end
     end
   end
 
@@ -72,7 +73,7 @@ class EmailVerifier::Checker
 
   def rcptto(address)
     ensure_connected
-   
+
     begin
       ensure_250 @smtp.rcptto(address)
     rescue => e


### PR DESCRIPTION
We needed the internal reason why EmailVerifier::OutOfMailServersException was caused. If retry is used rubies nested exceptions do not work.

```
begin
  EmailVerifier.check(email)
rescue EmailVerifier::OutOfMailServersException => e
  p e.cause
end
```
